### PR TITLE
Usa gunicorn en vez del server default de django

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -10,6 +10,7 @@ gunicorn = "*"
 django-heroku = "*"
 "psycopg2-binary" = "*"
 django-bootstrap4 = "*"
+whitenoise = "*"
 
 [dev-packages]
 pylint = "*"

--- a/scripts/start-server
+++ b/scripts/start-server
@@ -2,4 +2,4 @@
 
 [ $# -eq 2 ] || { echo "Usage: $0 <project-dir> <port>" &&  exit 1; }
 
-pipenv run sh -c "cd $1 && python manage.py runserver 0.0.0.0:$2"
+pipenv run sh -c "cd $1 && gunicorn secomplican.wsgi --bind=0.0.0.0:$2"

--- a/secomplican/secomplican/settings.py
+++ b/secomplican/secomplican/settings.py
@@ -31,7 +31,7 @@ SECRET_KEY = os.environ.get(
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = ['localhost', '.herokuapp.com']
+ALLOWED_HOSTS = ['127.0.0.1', 'localhost', '.herokuapp.com']
 
 
 # Application definition
@@ -49,6 +49,9 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    # Simplified static file serving.
+    # https://warehouse.python.org/project/whitenoise/
+    'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',


### PR DESCRIPTION
Así podemos atender muchos requests a la vez.

Tuve que poner también whitenoise para que gunicorn vea los staticfiles.