### PR TITLE
DEBUG depends on PRODUCTION environment variable

### DIFF
--- a/heroku.yml
+++ b/heroku.yml
@@ -1,8 +1,6 @@
 setup:
   addons:
    - plan: heroku-postgresql
-  config:
-    PRODUCTION: True
 build:
   docker:
     web: Dockerfile.web

--- a/heroku.yml
+++ b/heroku.yml
@@ -1,6 +1,8 @@
 setup:
   addons:
    - plan: heroku-postgresql
+  config:
+    PRODUCTION: True
 build:
   docker:
     web: Dockerfile.web

--- a/secomplican/secomplican/settings.py
+++ b/secomplican/secomplican/settings.py
@@ -29,7 +29,7 @@ SECRET_KEY = os.environ.get(
 )
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = not 'PRODUCTION' in os.environ
 
 ALLOWED_HOSTS = ['127.0.0.1', 'localhost', '.herokuapp.com']
 


### PR DESCRIPTION
So that the error pages don't show the stack trace on a production environment.