### PR TITLE
Mejoras del editor

### DIFF
--- a/secomplican/enunciados/static/enunciados/editor.js
+++ b/secomplican/enunciados/static/enunciados/editor.js
@@ -16,11 +16,11 @@ function surroundSelectionBy(before, after) {
 }
 
 function toolbarCodeHandler() {
-    surroundSelectionBy('```\n', '\n```');
+    surroundSelectionBy('```\n', '\n```\n');
 }
 
 function toolbarFormulaHandler() {
-    surroundSelectionBy('$$\n', '\n$$');
+    surroundSelectionBy('\\[\n', '\n\\]\n');
 }
 
 var toolbar = quill.getModule('toolbar');

--- a/secomplican/enunciados/static/enunciados/mathjax-config.js
+++ b/secomplican/enunciados/static/enunciados/mathjax-config.js
@@ -1,0 +1,5 @@
+MathJax.Hub.Config({
+    tex2jax: {
+        inlineMath: [['$','$'],["\\(","\\)"]]
+    }
+});

--- a/secomplican/enunciados/static/enunciados/style.css
+++ b/secomplican/enunciados/static/enunciados/style.css
@@ -16,6 +16,11 @@ body {
     white-space: pre !important;
 }
 
+.ql-right-link {
+    margin-right: 5px;
+    float: right;
+}
+
 pre {
     background-color: #f0f0f0;
     padding: 1em;

--- a/secomplican/enunciados/templates/base.html
+++ b/secomplican/enunciados/templates/base.html
@@ -9,8 +9,9 @@
   {# Para que la página sea responsive #}
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   {# MathJax #}
-  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
-  </script>
+  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+  <script type="text/javascript" src="{% static 'enunciados/mathjax-config.js' %}"></script>
+
   {# Font Awesome, para los iconos #}
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.4.1/css/all.css" integrity="sha384-5sAR7xN1Nv6T6+dT2mhtzEpVJvfS3NScPQTrOxhwjIuvcA67KV2R5Jz6kr4abQsz" crossorigin="anonymous">
   <link rel="stylesheet" type="text/css" href="{% static 'enunciados/style.css' %}">

--- a/secomplican/enunciados/templates/enunciados/quill_form_widget.html
+++ b/secomplican/enunciados/templates/enunciados/quill_form_widget.html
@@ -2,7 +2,7 @@
     <button class="ql-code"></button>
     <button class="ql-formula"></button>
 </div>
-<div id="editor" class="rounded-bottom" style="height: 200px">
+<div id="editor" class="rounded-bottom tex2jax_ignore" style="height: 200px">
     {% if field.value %}
         {{ field.value|linebreaksbr }}
     {% endif %}

--- a/secomplican/enunciados/templates/enunciados/quill_form_widget.html
+++ b/secomplican/enunciados/templates/enunciados/quill_form_widget.html
@@ -1,6 +1,10 @@
 <div id="toolbar" class="rounded-top">
     <button class="ql-code"></button>
     <button class="ql-formula"></button>
+    <a href="https://math.meta.stackexchange.com/q/5020/386164"
+    target="_blank" rel="noopener noreferrer" class="ql-right-link">
+        <small>Guía de formato</small>
+    </a>
 </div>
 <div id="editor" class="rounded-bottom tex2jax_ignore" style="height: 200px">
     {% if field.value %}


### PR DESCRIPTION
- Muestra los `$$ .. $$` cuando editas
- Podés poner inline math con `$ .. $`
- Agrega link de guía de formato a stackexchange
- Pone `\[ .. \]` en vez de `$$ .. $$` cuando apretás botón de código (funcionan los dos igual, pero creo que está recomendado el `\[ .. \]`)